### PR TITLE
Mauvais file_type avec la méthode post_local_file_and_media_info de RudiNodeWriter. - FIX

### DIFF
--- a/src/rudi_node_write/connectors/io_rudi_manager_write.py
+++ b/src/rudi_node_write/connectors/io_rudi_manager_write.py
@@ -1129,7 +1129,7 @@ class RudiNodeManagerConnector(Connector):
     def post_local_file(
         self,
         file_local_path: str,
-        media_id: str = uuid4_str(),
+        media_id: str | None = None,
         rudi_media: RudiMediaFile | None = None,
     ):
         """
@@ -1138,6 +1138,9 @@ class RudiNodeManagerConnector(Connector):
         :return:
         """
         here = f"{self.class_name}.post_local_file"
+
+        if media_id is None:
+            media_id = uuid4_str()
 
         if rudi_media is None:
             rudi_media = RudiMediaFile.from_local_file(file_local_path, media_id)
@@ -1291,7 +1294,7 @@ class RudiNodeStorageConnector(Connector):
     def post_local_file(
         self,
         file_local_path: str,
-        media_id: str = uuid4_str(),
+        media_id: str | None = None,
         rudi_media: RudiMediaFile | None = None,
     ):
         """
@@ -1305,6 +1308,9 @@ class RudiNodeStorageConnector(Connector):
         # :param file_type: the MIME type of the file
         # :param charset: the encoding of the file
         here = f"{self.class_name}.post_local_file"
+
+        if media_id is None:
+            media_id = uuid4_str()
 
         if rudi_media is None:
             rudi_media = RudiMediaFile.from_local_file(file_local_path, media_id)

--- a/src/rudi_node_write/connectors/io_rudi_manager_write_v3.py
+++ b/src/rudi_node_write/connectors/io_rudi_manager_write_v3.py
@@ -1125,7 +1125,7 @@ class RudiNodeManagerConnectorV3(RudiNodeManagerConnector):
     def post_local_file(
         self,
         file_local_path: str,
-        media_id: str = uuid4_str(),
+        media_id: str | None = None,
         rudi_media: RudiMediaFile | None = None,
     ) -> RudiMediaFile:
         """
@@ -1134,6 +1134,9 @@ class RudiNodeManagerConnectorV3(RudiNodeManagerConnector):
         :return:
         """
         here = f"{self.class_name}.post_local_file"
+
+        if media_id is None:
+            media_id = uuid4_str()
 
         if rudi_media is None:
             rudi_media = RudiMediaFile.from_local_file(file_local_path, media_id)
@@ -1336,6 +1339,9 @@ class RudiNodeStorageConnectorV3(Connector):
         # :param file_type: the MIME type of the file
         # :param charset: the encoding of the file
         here = f"{self.class_name}.post_local_file"
+
+        if media_id is None:
+            media_id = uuid4_str()
 
         if rudi_media is None:
             rudi_media = RudiMediaFile.from_local_file(file_local_path, media_id)

--- a/src/rudi_node_write/rudi_node_writer.py
+++ b/src/rudi_node_write/rudi_node_writer.py
@@ -16,7 +16,7 @@ from rudi_node_write.utils.dict_utils import (
 )
 from rudi_node_write.utils.file_utils import read_json_file
 from rudi_node_write.utils.log import log_d
-from rudi_node_write.utils.str_utils import absolute_path, check_is_string, check_is_uuid4, slash_join, uuid4_str
+from rudi_node_write.utils.str_utils import absolute_path, check_is_string, check_is_uuid4, slash_join
 from rudi_node_write.utils.type_date import Date
 
 _USER_AGENT_DEFAULT = "RudiNodeWriter"
@@ -487,7 +487,7 @@ class RudiNodeWriter:
     def post_local_file_and_media_info(
         self,
         file_local_path: str,
-        media_id: str = uuid4_str(),
+        media_id: str | None = None,
         rudi_media: RudiMediaFile | None = None,
     ) -> RudiMediaFile:
         """

--- a/src/rudi_node_write/rudi_types/rudi_media.py
+++ b/src/rudi_node_write/rudi_types/rudi_media.py
@@ -413,8 +413,10 @@ class RudiMediaFile(RudiMedia):
         self.file_status_update = Date.now_iso_str()
 
     @staticmethod
-    def from_local_file(file_local_path: str, media_id: str | None = uuid4_str(), file_url: str = "to_be_provided"):
+    def from_local_file(file_local_path: str, media_id: str | None = None, file_url: str = "to_be_provided"):
         here = f"{RudiMediaFile}.from_local_file"
+        if media_id is None:
+            media_id = uuid4_str()
         file_info = FileDetails(file_local_path)
         log_d(here, "file_info", file_info)
         return RudiMediaFile(


### PR DESCRIPTION
Root cause: Python mutable default argument
The media_id parameter had uuid4_str() as its default value in function signatures.

Set None as the default nd calls uuid4_str() inside the function body, so a fresh UUID is generated on every call.

Original Issue: https://github.com/OlivierMartineau/rudi-node-write/issues/1